### PR TITLE
Deprecate binding

### DIFF
--- a/src/WriteVTK.jl
+++ b/src/WriteVTK.jl
@@ -22,8 +22,11 @@ import Base: close, isopen
 # Cell type definitions as in vtkCellType.h
 include("VTKCellTypes.jl")
 
-# Base.@eprecate_binding VTKCellType VTKCellTypes
-const VTKCellType = VTKCellTypes # VTKCellType is deprecated, use VTKCellTypes instead
+if VERSION >= v"0.5"
+    Base.@deprecate_binding VTKCellType VTKCellTypes
+else
+    const VTKCellType = VTKCellTypes
+end
 
 ## Constants ##
 const COMPRESSION_LEVEL = 6


### PR DESCRIPTION
Since [this](https://github.com/JuliaLang/julia/pull/18392) made it into the 0.5.0 release the old name can now be deprecated using `@deprecate_binding`. On 0.5.0:

```jl
julia> using WriteVTK

julia> VTKCellType
WARNING: WriteVTK.VTKCellType is deprecated, use WriteVTK.VTKCellTypes instead.
  likely near no file:0
WriteVTK.VTKCellTypes
```
