### PR TITLE
Relax time to real from float

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ VTK files are then added to the `pvd` file with
 collection_add_timestep(pvd, vtkfile, time)
 ```
 
-Here, `time` is a float that represents the current time in the simulation.
+Here, `time` is a number that represents the current time (or step) in the simulation.
 When all the files are added to the `pvd` file, it can be saved using:
 
 ``` julia

--- a/src/gridtypes/ParaviewCollection.jl
+++ b/src/gridtypes/ParaviewCollection.jl
@@ -16,7 +16,7 @@ function paraview_collection(filename_noext::AbstractString)
 end
 
 function collection_add_timestep(pvd::CollectionFile, datfile::VTKFile,
-                                 t::AbstractFloat)
+                                 t::Real)
     xroot = root(pvd.xdoc)
     xMBDS = find_element(xroot, "Collection")
     xDataSet = new_child(xMBDS, "DataSet")


### PR DESCRIPTION
Fixes one of my most common errors when using pvd-files, since I usually just use the step number, and it annoys me that I have to do this:
```jl
collection_add_timestep(pvdfile, vtkfile, float(i))
```
:smile: 