### PR TITLE
Save incrementally instead of keeping it all in RAM

### DIFF
--- a/src/WriteVTK.jl
+++ b/src/WriteVTK.jl
@@ -70,7 +70,7 @@ end
 immutable CollectionFile <: VTKFile
     xdoc::XMLDocument
     path::UTF8String
-    timeSteps::Vector{VTKFile}
+    timeSteps::Vector{UTF8String}
     # Constructor.
     CollectionFile(xdoc, path) = new(xdoc, path, VTKFile[])
 end

--- a/src/gridtypes/ParaviewCollection.jl
+++ b/src/gridtypes/ParaviewCollection.jl
@@ -24,17 +24,13 @@ function collection_add_timestep(pvd::CollectionFile, datfile::VTKFile,
     set_attribute(xDataSet, "timestep", @sprintf("%f", t))
     set_attribute(xDataSet, "part", "0")
     set_attribute(xDataSet, "file", fname)
-    push!(pvd.timeSteps, datfile)
+    append!(pvd.timeSteps, vtk_save(datfile))
     return
 end
 
 function vtk_save(pvd::CollectionFile)
     # Saves paraview collection file (.pvd).
-    # Also saves the contained data files recursively.
-    outfiles = [pvd.path]::Vector{UTF8String}
-    for vtk in pvd.timeSteps
-        append!(outfiles, vtk_save(vtk))
-    end
+    outfiles = [pvd.path; pvd.timeSteps]::Vector{UTF8String}
     if isopen(pvd)
         save_file(pvd.xdoc, pvd.path)
         close(pvd)


### PR DESCRIPTION
This will leave a bunch of garbage vtk if the program crashes, should probably save to a tempdir, and when storing the pvd file move them to the correct dir.