### PR TITLE
return vtk file from vtk_point_or_cell_data

### DIFF
--- a/src/gridtypes/common.jl
+++ b/src/gridtypes/common.jl
@@ -183,7 +183,7 @@ function vtk_point_or_cell_data(vtk::DatasetFile, data::AbstractArray,
     # DataArray node
     xDA = data_to_xml(vtk, xPD, data, name, Nc)
 
-    return
+    return vtk
 end
 
 


### PR DESCRIPTION
 This allows for nesting of functions, e.g. something like this works:
```julia
julia> vtk_save(vtk_point_data(vtk_grid("name", collect(0:5), collect(0:5)), rand(6*6), "field"))
1-element Array{String,1}:
 "name.vtr"
```