### PR TITLE
[RFC] let the user add the file extension

### DIFF
--- a/src/WriteVTK.jl
+++ b/src/WriteVTK.jl
@@ -96,6 +96,21 @@ MeshCell(ctype, conn::V) where V = MeshCell{V}(ctype, conn)
 close(vtk::VTKFile) = free(vtk.xdoc)
 isopen(vtk::VTKFile) = (vtk.xdoc.ptr != C_NULL)
 
+# Add a default extension to the filename,
+# unless the user have already given the correct one
+function add_extension(filename, default_extension)
+    path, ext = splitext(filename)
+    if ext != default_extension
+        if ext in ("vtu", "vtr", "vts", "vti", "pvd", "vtm")
+            warn("detected extension '$(ext)' does not correspond to dataset type. ",
+                "Appending '$(default_extension)' to filename.")
+        end
+        return filename * default_extension
+    else
+        return filename
+    end
+end
+
 # Multiblock-specific functions and types.
 include("gridtypes/multiblock.jl")
 include("gridtypes/ParaviewCollection.jl")

--- a/src/gridtypes/ParaviewCollection.jl
+++ b/src/gridtypes/ParaviewCollection.jl
@@ -1,6 +1,6 @@
-function paraview_collection(filename_noext::AbstractString)
+function paraview_collection(filename::AbstractString)
     # Initialise Paraview collection file (extension .pvd).
-    # filename_noext: filename without the extension (.pvd).
+    # filename: filename with or without the extension (.pvd).
     xpvd = XMLDocument()
     xroot = create_root(xpvd, "VTKFile")
     set_attribute(xroot, "type", "Collection")
@@ -12,7 +12,7 @@ function paraview_collection(filename_noext::AbstractString)
     end
     set_attribute(xroot, "compressor", "vtkZLibDataCompressor")
     new_child(xroot, "Collection")
-    return CollectionFile(xpvd, string(filename_noext, ".pvd"))
+    return CollectionFile(xpvd, add_extension(filename, ".pvd"))
 end
 
 function collection_add_timestep(pvd::CollectionFile, datfile::VTKFile,

--- a/src/gridtypes/array.jl
+++ b/src/gridtypes/array.jl
@@ -5,13 +5,13 @@ Useful for general visualisation of arrays.
 The input can be a 2D or 3D array.
 
 """
-function vtk_write_array(filename_noext::AbstractString,
+function vtk_write_array(filename::AbstractString,
                          array::AbstractArray{T},
                          label::AbstractString="array") where T <: Real
     if !(2 <= ndims(array) <= 3)
         throw(ArgumentError("Input should be a 2D or 3D array."))
     end
-    vtkfile = vtk_grid(filename_noext, size(array)...)
+    vtkfile = vtk_grid(filename, size(array)...)
     vtk_point_data(vtkfile, array, label)
     vtk_save(vtkfile)
 end

--- a/src/gridtypes/imagedata.jl
+++ b/src/gridtypes/imagedata.jl
@@ -1,4 +1,4 @@
-function vtk_grid(filename_noext::AbstractString,
+function vtk_grid(filename::AbstractString,
                   Nx::Integer, Ny::Integer, Nz::Integer=1;
                   origin::AbstractArray=[0.0, 0.0, 0.0],
                   spacing::AbstractArray=[1.0, 1.0, 1.0],
@@ -8,7 +8,7 @@ function vtk_grid(filename_noext::AbstractString,
     ext = extent_attribute(Nx, Ny, Nz, extent)
 
     xvtk = XMLDocument()
-    vtk = DatasetFile(xvtk, filename_noext*".vti", "ImageData",
+    vtk = DatasetFile(xvtk, add_extension(filename, ".vti"), "ImageData",
                       Npts, Ncls, compress, append)
 
     # VTKFile node

--- a/src/gridtypes/multiblock.jl
+++ b/src/gridtypes/multiblock.jl
@@ -1,6 +1,6 @@
-function vtk_multiblock(filename_noext::AbstractString)
+function vtk_multiblock(filename::AbstractString)
     # Initialise VTK multiblock file (extension .vtm).
-    # filename_noext: filename without the extension (.vtm).
+    # filename: filename with or without the extension (.vtm).
     xvtm = XMLDocument()
     xroot = create_root(xvtm, "VTKFile")
     set_attribute(xroot, "type", "vtkMultiBlockDataSet")
@@ -11,7 +11,7 @@ function vtk_multiblock(filename_noext::AbstractString)
         set_attribute(xroot, "byte_order", "BigEndian")
     end
     new_child(xroot, "vtkMultiBlockDataSet")
-    return MultiblockFile(xvtm, string(filename_noext, ".vtm"))
+    return MultiblockFile(xvtm, add_extension(filename, ".vtm"))
 end
 
 function vtk_grid(vtm::MultiblockFile, griddata...; kwargs...)

--- a/src/gridtypes/rectilinear.jl
+++ b/src/gridtypes/rectilinear.jl
@@ -1,4 +1,4 @@
-function rectilinear_grid(filename_noext::AbstractString, x::AbstractVector,
+function rectilinear_grid(filename::AbstractString, x::AbstractVector,
                           y::AbstractVector, z::AbstractVector;
                           compress=true, append::Bool=true,
                           extent=nothing)
@@ -8,7 +8,7 @@ function rectilinear_grid(filename_noext::AbstractString, x::AbstractVector,
     ext = extent_attribute(Ni, Nj, Nk, extent)
 
     xvtk = XMLDocument()
-    vtk = DatasetFile(xvtk, filename_noext*".vtr", "RectilinearGrid",
+    vtk = DatasetFile(xvtk, add_extension(filename, ".vtr"), "RectilinearGrid",
                       Npts, Ncls, compress, append)
 
     # VTKFile node
@@ -34,11 +34,11 @@ function rectilinear_grid(filename_noext::AbstractString, x::AbstractVector,
 end
 
 # 3D variant
-vtk_grid(filename_noext::AbstractString, x::AbstractVector{T},
+vtk_grid(filename::AbstractString, x::AbstractVector{T},
          y::AbstractVector{T}, z::AbstractVector{T}; kwargs...) where T =
-    rectilinear_grid(filename_noext, x, y, z; kwargs...)
+    rectilinear_grid(filename, x, y, z; kwargs...)
 
 # 2D variant
-vtk_grid(filename_noext::AbstractString, x::AbstractVector{T},
+vtk_grid(filename::AbstractString, x::AbstractVector{T},
          y::AbstractVector{T}; kwargs...) where T =
-    rectilinear_grid(filename_noext, x, y, zeros(T, 1); kwargs...)
+    rectilinear_grid(filename, x, y, zeros(T, 1); kwargs...)

--- a/src/gridtypes/structured.jl
+++ b/src/gridtypes/structured.jl
@@ -1,4 +1,4 @@
-function structured_grid(filename_noext::AbstractString, xyz::AbstractArray;
+function structured_grid(filename::AbstractString, xyz::AbstractArray;
                          compress=true, append::Bool=true, extent=nothing)
     Ncomp, Ni, Nj, Nk = size(xyz)
     Npts = Ni*Nj*Nk
@@ -13,7 +13,7 @@ function structured_grid(filename_noext::AbstractString, xyz::AbstractArray;
     end
 
     xvtk = XMLDocument()
-    vtk = DatasetFile(xvtk, filename_noext*".vts", "StructuredGrid",
+    vtk = DatasetFile(xvtk, add_extension(filename, ".vts"), "StructuredGrid",
                       Npts, Ncls, compress, append)
 
     # VTKFile node
@@ -38,13 +38,13 @@ end
 
 
 # 3D variant of vtk_grid with 4D array xyz.
-vtk_grid(filename_noext::AbstractString, xyz::AbstractArray{T,4};
+vtk_grid(filename::AbstractString, xyz::AbstractArray{T,4};
          kwargs...) where T =
-    structured_grid(filename_noext, xyz; kwargs...)
+    structured_grid(filename, xyz; kwargs...)
 
 
 # 3D variant of vtk_grid with 3D arrays x, y, z.
-function vtk_grid(filename_noext::AbstractString, x::AbstractArray{T,3},
+function vtk_grid(filename::AbstractString, x::AbstractArray{T,3},
                   y::AbstractArray{T,3}, z::AbstractArray{T,3};
                   kwargs...) where T
     if !(size(x) == size(y) == size(z))
@@ -57,12 +57,12 @@ function vtk_grid(filename_noext::AbstractString, x::AbstractArray{T,3},
         xyz[2, i, j, k] = y[i, j, k]
         xyz[3, i, j, k] = z[i, j, k]
     end
-    structured_grid(filename_noext, xyz; kwargs...)
+    structured_grid(filename, xyz; kwargs...)
 end
 
 
 # 2D variant of vtk_grid with 3D array xy
-function vtk_grid(filename_noext::AbstractString, xy::AbstractArray{T,3};
+function vtk_grid(filename::AbstractString, xy::AbstractArray{T,3};
                   kwargs...) where T
     Ncomp, Ni, Nj = size(xy)
     if Ncomp != 2
@@ -76,12 +76,12 @@ function vtk_grid(filename_noext::AbstractString, xy::AbstractArray{T,3};
     for j = 1:Nj, i = 1:Ni, n = 1:2
         xyz[n, i, j, 1] = xy[n, i, j]
     end
-    structured_grid(filename_noext, xyz; kwargs...)
+    structured_grid(filename, xyz; kwargs...)
 end
 
 
 # 2D variant of vtk_grid with 2D arrays x, y.
-function vtk_grid(filename_noext::AbstractString, x::AbstractArray{T,2},
+function vtk_grid(filename::AbstractString, x::AbstractArray{T,2},
                   y::AbstractArray{T,2}; kwargs...) where T
     if size(x) != size(y)
         throw(ArgumentError("Size of x and y arrays must be the same."))
@@ -93,5 +93,5 @@ function vtk_grid(filename_noext::AbstractString, x::AbstractArray{T,2},
         xyz[1, i, j, 1] = x[i, j]
         xyz[2, i, j, 1] = y[i, j]
     end
-    structured_grid(filename_noext, xyz; kwargs...)
+    structured_grid(filename, xyz; kwargs...)
 end

--- a/src/gridtypes/unstructured.jl
+++ b/src/gridtypes/unstructured.jl
@@ -1,4 +1,4 @@
-function unstructured_grid(filename_noext::AbstractString, points::AbstractArray,
+function unstructured_grid(filename::AbstractString, points::AbstractArray,
                            cells::Vector{<:MeshCell};
                            compress=true, append::Bool=true)
     @assert size(points, 1) == 3
@@ -6,7 +6,7 @@ function unstructured_grid(filename_noext::AbstractString, points::AbstractArray
     Ncls = length(cells)
 
     xvtk = XMLDocument()
-    vtk = DatasetFile(xvtk, filename_noext*".vtu", "UnstructuredGrid",
+    vtk = DatasetFile(xvtk, add_extension(filename, ".vtu"), "UnstructuredGrid",
                       Npts, Ncls, compress, append)
 
     # VTKFile node
@@ -69,11 +69,11 @@ end
 
 # Variant of vtk_grid with 2-D array "points".
 #   size(points) = (dim, num_points), with dim ∈ {1, 2, 3}
-function vtk_grid(filename_noext::AbstractString, points::AbstractArray{T,2},
+function vtk_grid(filename::AbstractString, points::AbstractArray{T,2},
                   cells::Vector{<:MeshCell}; kwargs...) where T
     dim, Npts = size(points)
     if dim == 3
-        return unstructured_grid(filename_noext, points, cells; kwargs...)
+        return unstructured_grid(filename, points, cells; kwargs...)
     end
     # Reshape to 3D
     _points = zeros(T, 3, Npts)
@@ -87,12 +87,12 @@ function vtk_grid(filename_noext::AbstractString, points::AbstractArray{T,2},
                      "Actual size of input: $(size(points))")
         throw(ArgumentError(msg))
     end
-    unstructured_grid(filename_noext, _points, cells; kwargs...)
+    unstructured_grid(filename, _points, cells; kwargs...)
 end
 
 # Variant of vtk_grid with 1-D arrays x, y, z.
 # Size of each array: (num_points)
-function vtk_grid(filename_noext::AbstractString, x::AbstractVector{T},
+function vtk_grid(filename::AbstractString, x::AbstractVector{T},
                   y::AbstractVector{T}, z::AbstractVector{T},
                   cells::Vector{<:MeshCell}; kwargs...) where T
     if !(length(x) == length(y) == length(z))
@@ -105,25 +105,25 @@ function vtk_grid(filename_noext::AbstractString, x::AbstractVector{T},
         points[2, n] = y[n]
         points[3, n] = z[n]
     end
-    unstructured_grid(filename_noext, points, cells; kwargs...)
+    unstructured_grid(filename, points, cells; kwargs...)
 end
 
 # 2D version
-vtk_grid(filename_noext::AbstractString, x::AbstractVector{T},
+vtk_grid(filename::AbstractString, x::AbstractVector{T},
          y::AbstractVector{T}, cells::Vector{<:MeshCell};
          kwargs...) where T =
-    vtk_grid(filename_noext, x, y, zero(x), cells; kwargs...)
+    vtk_grid(filename, x, y, zero(x), cells; kwargs...)
 
 # 1D version
-vtk_grid(filename_noext::AbstractString, x::AbstractVector{T},
+vtk_grid(filename::AbstractString, x::AbstractVector{T},
          cells::Vector{<:MeshCell}; kwargs...) where T =
-    vtk_grid(filename_noext, x, zero(x), zero(x), cells; kwargs...)
+    vtk_grid(filename, x, zero(x), zero(x), cells; kwargs...)
 
 # Variant with 4-D Array (for "pseudo-unstructured" datasets, i.e., those that
 # actually have a 3D structure) -- maybe this variant should be removed...
-function vtk_grid(filename_noext::AbstractString, points::AbstractArray{T,4},
+function vtk_grid(filename::AbstractString, points::AbstractArray{T,4},
                   cells::Vector{<:MeshCell}; kwargs...) where T
     dim, Ni, Nj, Nk = size(points)
     points_r = reshape(points, (dim, Ni*Nj*Nk))
-    unstructured_grid(filename_noext, points_r, cells; kwargs...)
+    unstructured_grid(filename, points_r, cells; kwargs...)
 end


### PR DESCRIPTION
Usually when printing to file you have to supply the file extension yourself. This adds a normalization function, that lets the user include the extension in the filename but error out if it does not match the expected exenstion.

After coding this and running the test I realize that this will not quite work, because here https://github.com/jipolanco/WriteVTK.jl/blob/248058f09801ab3805cf20d144d2312043a8cb8f/src/gridtypes/multiblock.jl#L21 we generate filenames with `.` and hence `splitext` splits the name there. Is this `.` in the multiblock file required by the VTK format? Or could we change that to something else, like a dash?

We could also choose not to error out, and instead define something like
```
function add_file_extension(filename, expected_extension)
    path, ext = splitext(filename)
    if ext != expected_extension
        return filename * expected_extension
    else
        return filename
    end
end
```
i.e. always add the extension, unless it matches the expected one. This would change  the current behaviour of `vtk_grid("myfile.vtu")` since it would return a `myfile.vtu` file instead of the current behavior: a `myfile.vtu.vtu` file. Hopefully no one is relying on that...