### PR TITLE
Add TranscodingStreams to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 LightXML 0.4.0
 CodecZlib 0.4.2
 Compat 0.41.0  # Printf
+TranscodingStreams 0.5.2


### PR DESCRIPTION
With the recent Julia 0.7-alpha release, WriteVTK.jl fails to build as TranscodingStreams is not available. This PR adds TranscodingStreams to the REQUIRE list of WriteVTK.jl.

The Julia 0.6 and 0.7-alpha builds complete successfully on [my fork](https://travis-ci.org/anders-dc/WriteVTK.jl/builds/386835130).