### PR TITLE
Add function for loading an existing pvd file

### DIFF
--- a/src/WriteVTK.jl
+++ b/src/WriteVTK.jl
@@ -10,7 +10,7 @@ export VTKCellTypes, VTKCellType
 export MeshCell
 export vtk_grid, vtk_save, vtk_point_data, vtk_cell_data
 export vtk_multiblock
-export paraview_collection, collection_add_timestep
+export paraview_collection, collection_add_timestep, paraview_collection_load
 export vtk_write_array
 
 import CodecZlib: ZlibCompressorStream

--- a/src/gridtypes/ParaviewCollection.jl
+++ b/src/gridtypes/ParaviewCollection.jl
@@ -15,6 +15,26 @@ function paraview_collection(filename::AbstractString)
     return CollectionFile(xpvd, add_extension(filename, ".pvd"))
 end
 
+function paraview_collection_load(filename::AbstractString)
+    pvd_filename = add_extension(filename, ".pvd")
+    xpvd = parse_file(pvd_filename)
+    pvd = paraview_collection(filename)
+    xroot = root(pvd.xdoc)
+    xMBDS = find_element(xroot, "Collection")
+    # Iterate the child elements and only add 
+    # attributes considered by pvd.
+    # This also preserves the formatting of the resulting
+    # file as the empty textnodes created during loading
+    # are removed.
+    for c in child_elements(find_element(root(xpvd),"Collection"))
+        xDataSet = new_child(xMBDS, "DataSet")
+        set_attribute(xDataSet, "timestep",attribute(c,"timestep"))
+        set_attribute(xDataSet, "part",attribute(c,"part"))
+        set_attribute(xDataSet, "file",attribute(c,"file"))
+    end
+    return pvd
+end
+
 function collection_add_timestep(pvd::CollectionFile, datfile::VTKFile,
                                  t::Real)
     xroot = root(pvd.xdoc)

--- a/src/gridtypes/ParaviewCollection.jl
+++ b/src/gridtypes/ParaviewCollection.jl
@@ -26,11 +26,11 @@ function paraview_collection_load(filename::AbstractString)
     # This also preserves the formatting of the resulting
     # file as the empty textnodes created during loading
     # are removed.
-    for c in child_elements(find_element(root(xpvd),"Collection"))
+    for c in child_elements(find_element(root(xpvd), "Collection"))
         xDataSet = new_child(xMBDS, "DataSet")
-        set_attribute(xDataSet, "timestep",attribute(c,"timestep"))
-        set_attribute(xDataSet, "part",attribute(c,"part"))
-        set_attribute(xDataSet, "file",attribute(c,"file"))
+        set_attribute(xDataSet, "timestep", attribute(c, "timestep"))
+        set_attribute(xDataSet, "part", attribute(c, "part"))
+        set_attribute(xDataSet, "file", attribute(c, "file"))
     end
     return pvd
 end

--- a/test/checksums.sha1
+++ b/test/checksums.sha1
@@ -18,6 +18,7 @@ e3fba45837361d8c8dfed8ca98a43c4498a9c3b0  unstructured_2D.vtu
 2d3b1246cbc7c5b970a1f01134ecd3224dc297cd  collection_01.vtr
 ef5d75a0cc9e857341d4a9ace3e0c5b046b30557  collection_02.vtr
 bc71e96c6e106a01773592513a5efa81660a3dd3  collection_03.vtr
+4719f89362994e2412f00f506c338d0077a0a35f  collection_reload.pvd
 5b581aa05c4020de2a21a860213b6b787e2e78a3  arraydata_2D.vti
 50f3bab5f4b5b9a4f7bdd960ddaf57c3c7581549  arraydata_3D.vti
 af27710fb6c20a5e5db7f9bcff07f56658887c09  arrays.vti

--- a/test/checksums.sha1
+++ b/test/checksums.sha1
@@ -19,6 +19,7 @@ e3fba45837361d8c8dfed8ca98a43c4498a9c3b0  unstructured_2D.vtu
 ef5d75a0cc9e857341d4a9ace3e0c5b046b30557  collection_02.vtr
 bc71e96c6e106a01773592513a5efa81660a3dd3  collection_03.vtr
 4719f89362994e2412f00f506c338d0077a0a35f  collection_reload.pvd
+69ca28f0dc18ef7ddc334253fd9ddc9ab12f0a09  collection_reload.vtr
 5b581aa05c4020de2a21a860213b6b787e2e78a3  arraydata_2D.vti
 50f3bab5f4b5b9a4f7bdd960ddaf57c3c7581549  arraydata_3D.vti
 af27710fb6c20a5e5db7f9bcff07f56658887c09  arrays.vti

--- a/test/pvdCollection.jl
+++ b/test/pvdCollection.jl
@@ -75,17 +75,19 @@ function main()
     end
 
     # Create a copy of above pvd for reloading
-    cp(vtk_filename_noext*".pvd",vtk_filename_noext*"_reload.pvd",force=true)
-    pvd_reload = paraview_collection_load(vtk_filename_noext*"_reload")
+    cp(vtk_filename_noext * ".pvd",
+       vtk_filename_noext * "_reload.pvd",
+       force=true)
+    pvd_reload = paraview_collection_load(vtk_filename_noext * "_reload")
 
     # add a vtk file
-    vtk_reload = vtk_grid("collection_reload",[1,2,3],[1,2,3])
-    collection_add_timestep(pvd_reload,vtk_reload,5.0)
+    vtk_reload = vtk_grid("collection_reload", [1, 2, 3], [1, 2, 3])
+    collection_add_timestep(pvd_reload, vtk_reload, 5.0)
     pvd_reload_files = vtk_save(pvd_reload)
     append!(outfiles, pvd_reload_files)
 
     println("Saved:  ", join(outfiles, "  "))
-    
+
     return outfiles::Vector{String}
 end
 

--- a/test/pvdCollection.jl
+++ b/test/pvdCollection.jl
@@ -81,10 +81,8 @@ function main()
     # add a vtk file
     vtk_reload = vtk_grid("collection_reload",[1,2,3],[1,2,3])
     collection_add_timestep(pvd_reload,vtk_reload,5.0)
-    # Remove the file again, its not needed for testing
-    rm(vtk_reload.path)
-    vtk_save(pvd_reload)
-    push!(outfiles,vtk_filename_noext*"_reload.pvd")
+    pvd_reload_files = vtk_save(pvd_reload)
+    append!(outfiles, pvd_reload_files)
 
     println("Saved:  ", join(outfiles, "  "))
     

--- a/test/pvdCollection.jl
+++ b/test/pvdCollection.jl
@@ -73,8 +73,21 @@ function main()
             collection_add_timestep(pvd, vtk, Float64(it+1))
         end
     end
-    println("Saved:  ", join(outfiles, "  "))
 
+    # Create a copy of above pvd for reloading
+    cp(vtk_filename_noext*".pvd",vtk_filename_noext*"_reload.pvd",force=true)
+    pvd_reload = paraview_collection_load(vtk_filename_noext*"_reload")
+
+    # add a vtk file
+    vtk_reload = vtk_grid("collection_reload",[1,2,3],[1,2,3])
+    collection_add_timestep(pvd_reload,vtk_reload,5.0)
+    # Remove the file again, its not needed for testing
+    rm(vtk_reload.path)
+    vtk_save(pvd_reload)
+    push!(outfiles,vtk_filename_noext*"_reload.pvd")
+
+    println("Saved:  ", join(outfiles, "  "))
+    
     return outfiles::Vector{String}
 end
 


### PR DESCRIPTION
Adds `paraview_collection_load` that loads an existing pvd file. This allows appending new vtk files to the collection.

As mentioned in the comment, loading added some empty text nodes which messed up the formatting. Not a big deal but this way the file looks cleaner and structurally matches the original file.

Some points for discussion:
1. `paraview_collection_load` could be the default behavior for `paraview_collection` if the pvd already exists . However this contradicts vtk file saving/creating. I think it's better to leave that to the user.
2. On `vtk_save(pvd)` now only the newly added VTK files are returned. I don't know what the motivation was for returning all files. I could push the old files during loading so all files are returned if this is better.