### PR TITLE
Extend VTKDataType from String to AbstractString

### DIFF
--- a/src/write_data.jl
+++ b/src/write_data.jl
@@ -67,7 +67,7 @@ guess_data_location(data::Tuple{}, args...) = VTKPointData()
 Union of data types allowed by VTK.
 """
 const VTKDataType = Union{Int8, UInt8, Int16, UInt16, Int32, UInt32,
-                          Int64, UInt64, Float32, Float64, String}
+                          Int64, UInt64, Float32, Float64, AbstractString}
 
 # Return the VTK string representation of a numerical data type.
 function datatype_str(::Type{T}) where T <: VTKDataType


### PR DESCRIPTION
Now that field data is supported, we should allow generic string type to be passed.