### PR TITLE
Fix `Vararg` in UnionAll deprecation issue

### DIFF
--- a/src/gridtypes/structured/structured.jl
+++ b/src/gridtypes/structured/structured.jl
@@ -1,7 +1,7 @@
 # Structured dataset coordinates can be specified using either a 4D array
 # (3, Ni, Nj, Nk), or a tuple (x, y, z).
 const Array4 = AbstractArray{T, 4} where T
-const Array3Tuple3 = Tuple{Vararg{<:AbstractArray{T,3}, 3}} where T
+const Array3Tuple3 = Tuple{Vararg{AbstractArray{T,3}, 3}} where T
 const StructuredCoords = Union{Array4, Array3Tuple3}
 
 structured_dims(xyz::Array4) = ntuple(d -> size(xyz, d + 1), 3)


### PR DESCRIPTION
fixes #82 

`Tuple{Vararg{<:AbstractArray{T,3}, 3}} where T` returns `Tuple{Vararg{AbstractArray{T, 3}, 3}} where T` in Julia 1.5/1.6 anyways.