### PR TITLE
Rework VTK extents for structured grids

### DIFF
--- a/src/gridtypes/common.jl
+++ b/src/gridtypes/common.jl
@@ -18,7 +18,7 @@ end
 const Extent{N} = Tuple{Vararg{AbstractUnitRange{<:Integer}, N}} where {N}
 
 # Switch to zero-based extent used by VTK.
-to_vtk_extent(r::AbstractUnitRange) = oftype(r, r .- 1)
+to_vtk_extent(r::AbstractUnitRange) = r .- 1
 
 function to_vtk_extent(extent::Union{Tuple, AbstractArray})
     ext = to_extent3(extent)
@@ -33,11 +33,11 @@ function to_extent3(extent::Extent{N}) where {N}
         throw(ArgumentError("dimensionalities N > 3 not supported (got N = $N)"))
     elseif N < 3
         M = 3 - N
-        (extent..., ntuple(d -> 1:1, Val(M))...) :: Extent{3}
+        (extent..., ntuple(d -> Base.OneTo(1), Val(M))...) :: Extent{3}
     end
 end
 
-to_extent3(Ns::Dims) = to_extent3(map(N -> 1:N, Ns))
+to_extent3(Ns::Dims) = to_extent3(map(Base.OneTo, Ns))
 
 # Returns the "extent" attribute required for structured (including rectilinear)
 # grids.

--- a/src/gridtypes/common.jl
+++ b/src/gridtypes/common.jl
@@ -14,31 +14,48 @@ function vtk_xml_write_header(vtk::DatasetFile)
     xroot::XMLElement
 end
 
+# Specifies the "extent" of a structured grid, e.g. (1:4, 0:3, 1:42)
+const Extent{N} = Tuple{Vararg{AbstractUnitRange{<:Integer}, N}} where {N}
 
 # Returns the "extent" attribute required for structured (including rectilinear)
 # grids.
-extent_attribute(Ni, Nj, Nk, ::Nothing=nothing) =
-    "0 $(Ni - 1) 0 $(Nj - 1) 0 $(Nk - 1)"
+function extent_attribute(Ns::Dims{3}, extent::Extent{3})
+    all(pair -> pair[1] == length(pair[2]), zip(Ns, extent)) ||
+        throw(DimensionMismatch("extent is not consistent with dataset dimensions."))
+    iter = Iterators.map(e -> string(first(e), " ", last(e)), extent)
+    join(iter, " ")
+end
 
-function extent_attribute(Ni, Nj, Nk, extent::Array{T}) where T <: Integer
-    length(extent) == 6 || throw(ArgumentError("extent must have length 6."))
-    (extent[2] - extent[1] + 1 == Ni) &&
-    (extent[4] - extent[3] + 1 == Nj) &&
-    (extent[6] - extent[5] + 1 == Nk) ||
-    throw(ArgumentError("extent is not consistent with dataset dimensions."))
-    join(extent, " ")
+function extent_attribute(Ns::Dims{N}, extent::Extent{N}) where {N}
+    if N > 3
+        throw(ArgumentError("dimensionalities N > 3 not supported (got N = $N)"))
+    elseif N < 3
+        M = 3 - N
+        extent_attribute(
+            (Ns..., ntuple(d -> 1, Val(M))...),
+            (extent..., ntuple(d -> 0:0, Val(M))...),
+        )
+    end
+end
+
+function extent_attribute(Ns::Dims, ::Nothing = nothing)
+    ext = map(N -> 0:(N - 1), Ns)
+    extent_attribute(Ns, ext)
+end
+
+# This is left for compatibility...
+function extent_attribute(Ns::Dims{N}, ext::Array{T}) where {N, T <: Integer}
+    length(ext) == 2N || throw(ArgumentError("extent must have length $(2N)."))
+    rs = ntuple(i -> (ext[2i - 1]):(ext[2i]), Val(N))
+    extent_attribute(Ns, rs)
 end
 
 # Number of cells in structured grids.
 # In 3D, all cells are hexahedrons (i.e. VTK_HEXAHEDRON), and the number of
 # cells is (Ni-1)*(Nj-1)*(Nk-1). In 2D, they are quadrilaterals (VTK_QUAD), and in
 # 1D they are line segments (VTK_LINE).
-function num_cells_structured(Ni, Nj, Nk)
-    Ncls = one(Ni)
-    for N in (Ni, Nj, Nk)
-        Ncls *= max(1, N - 1)
-    end
-    Ncls
+function num_cells_structured(Ns::Dims)
+    prod(N -> max(1, N - 1), Ns)
 end
 
 # Accept passing coordinates as a tuple.

--- a/src/gridtypes/common.jl
+++ b/src/gridtypes/common.jl
@@ -20,7 +20,7 @@ const Extent{N} = Tuple{Vararg{AbstractUnitRange{<:Integer}, N}} where {N}
 # Switch to zero-based extent used by VTK.
 to_vtk_extent(r::AbstractUnitRange) = r .- 1
 
-function to_vtk_extent(extent::Union{Tuple, AbstractArray})
+function to_vtk_extent(extent::Tuple)
     ext = to_extent3(extent)
     map(to_vtk_extent, ext)
 end

--- a/src/gridtypes/structured/imagedata.jl
+++ b/src/gridtypes/structured/imagedata.jl
@@ -15,7 +15,7 @@ function vtk_grid(
 
     # ImageData node
     xGrid = new_child(xroot, vtk.grid_type)
-    let ext = extent_attribute(Ns, whole_extent)
+    let ext = extent_attribute(Ns, whole_extent; check = false)
         set_attribute(xGrid, "WholeExtent", ext)
     end
 
@@ -27,7 +27,7 @@ function vtk_grid(
 
     # Piece node
     xPiece = new_child(xGrid, "Piece")
-    let ext = extent_attribute(Ns, extent)
+    let ext = extent_attribute(Ns, extent; check = true)
         set_attribute(xPiece, "Extent", ext)
     end
 

--- a/src/gridtypes/structured/imagedata.jl
+++ b/src/gridtypes/structured/imagedata.jl
@@ -41,7 +41,8 @@ function _tuple_to_str3(ts::NTuple{N, T}, default::T) where {N, T}
 end
 
 function vtk_grid(filename::AbstractString, Ns::Vararg{Integer}; kwargs...)
-    vtk_grid(filename, map(N -> 1:N, Ns)...; kwargs...)
+    # We put the origin at (0.0, 0.0, 0.0)
+    vtk_grid(filename, map(N -> range(0.0; length = N), Ns)...; kwargs...)
 end
 
 """

--- a/src/gridtypes/structured/imagedata.jl
+++ b/src/gridtypes/structured/imagedata.jl
@@ -2,7 +2,7 @@ function vtk_grid(
         dtype::VTKImageData, filename::AbstractString, Ns::Dims{N};
         origin::NTuple{N} = ntuple(d -> 0.0, Val(N)),
         spacing::NTuple{N} = ntuple(d -> 1.0, Val(N)),
-        extent = nothing, whole_extent = extent, kwargs...,
+        extent = Ns, whole_extent = extent, kwargs...,
     ) where {N}
     Npts = prod(Ns)
     Ncls = num_cells_structured(Ns)
@@ -15,7 +15,7 @@ function vtk_grid(
 
     # ImageData node
     xGrid = new_child(xroot, vtk.grid_type)
-    let ext = extent_attribute(Ns, whole_extent; check = false)
+    let ext = extent_attribute(whole_extent)
         set_attribute(xGrid, "WholeExtent", ext)
     end
 
@@ -27,7 +27,7 @@ function vtk_grid(
 
     # Piece node
     xPiece = new_child(xGrid, "Piece")
-    let ext = extent_attribute(Ns, extent; check = true)
+    let ext = extent_attribute(extent)
         set_attribute(xPiece, "Extent", ext)
     end
 

--- a/src/gridtypes/structured/imagedata.jl
+++ b/src/gridtypes/structured/imagedata.jl
@@ -79,8 +79,17 @@ VTK file 'def.vti' (ImageData file, open)
 """
 function vtk_grid(filename::AbstractString, xyz::Vararg{AbstractRange}; kwargs...)
     Nxyz = promote(length.(xyz)...)
-    origin = promote(first.(xyz)...)
     spacing = promote(step.(xyz)...)
+    origin = promote(first.(xyz)...)
+
+    if (extent = get(kwargs, :extent, nothing)) !== nothing
+        # Shift origin accordingly
+        length.(extent) == Nxyz ||
+            throw(DimensionMismatch("`extent` argument doesn't match grid dimensions"))
+        origin_new = @. origin + (1 - first(extent)) * spacing
+        origin = oftype(origin, origin_new)
+    end
+
     vtk_grid(VTKImageData(), filename, Nxyz;
              origin=origin, spacing=spacing, kwargs...)
 end

--- a/src/gridtypes/structured/imagedata.jl
+++ b/src/gridtypes/structured/imagedata.jl
@@ -78,9 +78,9 @@ VTK file 'def.vti' (ImageData file, open)
 
 """
 function vtk_grid(filename::AbstractString, xyz::Vararg{AbstractRange}; kwargs...)
-    Nxyz = length.(xyz)
-    origin = first.(xyz)
-    spacing = step.(xyz)
+    Nxyz = promote(length.(xyz)...)
+    origin = promote(first.(xyz)...)
+    spacing = promote(step.(xyz)...)
     vtk_grid(VTKImageData(), filename, Nxyz;
              origin=origin, spacing=spacing, kwargs...)
 end

--- a/src/gridtypes/structured/imagedata.jl
+++ b/src/gridtypes/structured/imagedata.jl
@@ -2,11 +2,10 @@ function vtk_grid(
         dtype::VTKImageData, filename::AbstractString, Ns::Dims{N};
         origin::NTuple{N} = ntuple(d -> 0.0, Val(N)),
         spacing::NTuple{N} = ntuple(d -> 1.0, Val(N)),
-        extent = nothing, kwargs...,
+        extent = nothing, whole_extent = extent, kwargs...,
     ) where {N}
     Npts = prod(Ns)
     Ncls = num_cells_structured(Ns)
-    ext = extent_attribute(Ns, extent)
 
     xvtk = XMLDocument()
     vtk = DatasetFile(dtype, xvtk, filename, Npts, Ncls; kwargs...)
@@ -16,7 +15,9 @@ function vtk_grid(
 
     # ImageData node
     xGrid = new_child(xroot, vtk.grid_type)
-    set_attribute(xGrid, "WholeExtent", ext)
+    let ext = extent_attribute(Ns, whole_extent)
+        set_attribute(xGrid, "WholeExtent", ext)
+    end
 
     origin_str = _tuple_to_str3(origin, zero(eltype(origin)))
     spacing_str = _tuple_to_str3(spacing, one(eltype(origin)))
@@ -26,7 +27,9 @@ function vtk_grid(
 
     # Piece node
     xPiece = new_child(xGrid, "Piece")
-    set_attribute(xPiece, "Extent", ext)
+    let ext = extent_attribute(Ns, extent)
+        set_attribute(xPiece, "Extent", ext)
+    end
 
     vtk
 end

--- a/src/gridtypes/structured/rectilinear.jl
+++ b/src/gridtypes/structured/rectilinear.jl
@@ -1,9 +1,9 @@
 function vtk_grid(
         dtype::VTKRectilinearGrid, filename::AbstractString,
         xs::Tuple{Vararg{AbstractVector, 3}};
-        extent = nothing, whole_extent = extent, kwargs...,
+        extent = map(length, xs), whole_extent = extent, kwargs...,
     )
-    Ns = length.(xs)
+    Ns = map(length, xs)
     Npts = prod(Ns)
     Ncls = num_cells_structured(Ns)
 
@@ -15,13 +15,13 @@ function vtk_grid(
 
     # RectilinearGrid node
     xGrid = new_child(xroot, vtk.grid_type)
-    let ext = extent_attribute(Ns, whole_extent; check = false)
+    let ext = extent_attribute(whole_extent)
         set_attribute(xGrid, "WholeExtent", ext)
     end
 
     # Piece node
     xPiece = new_child(xGrid, "Piece")
-    let ext = extent_attribute(Ns, extent; check = true)
+    let ext = extent_attribute(extent)
         set_attribute(xPiece, "Extent", ext)
     end
 

--- a/src/gridtypes/structured/rectilinear.jl
+++ b/src/gridtypes/structured/rectilinear.jl
@@ -1,10 +1,12 @@
-function vtk_grid(dtype::VTKRectilinearGrid, filename::AbstractString,
-                  x::AbstractVector, y::AbstractVector, z::AbstractVector;
-                  extent=nothing, kwargs...)
-    Ni, Nj, Nk = length(x), length(y), length(z)
-    Npts = Ni*Nj*Nk
-    Ncls = num_cells_structured((Ni, Nj, Nk))
-    ext = extent_attribute((Ni, Nj, Nk), extent)
+function vtk_grid(
+        dtype::VTKRectilinearGrid, filename::AbstractString,
+        xs::Tuple{Vararg{AbstractVector, 3}};
+        extent = nothing, kwargs...,
+    )
+    Ns = length.(xs)
+    Npts = prod(Ns)
+    Ncls = num_cells_structured(Ns)
+    ext = extent_attribute(Ns, extent)
 
     xvtk = XMLDocument()
     vtk = DatasetFile(dtype, xvtk, filename, Npts, Ncls; kwargs...)
@@ -24,6 +26,7 @@ function vtk_grid(dtype::VTKRectilinearGrid, filename::AbstractString,
     xPoints = new_child(xPiece, "Coordinates")
 
     # DataArray node
+    x, y, z = xs
     data_to_xml(vtk, xPoints, x, "x")
     data_to_xml(vtk, xPoints, y, "y")
     data_to_xml(vtk, xPoints, z, "z")
@@ -48,11 +51,11 @@ VTK file 'abc.vtr' (RectilinearGrid file, open)
 ```
 
 """
-vtk_grid(filename::AbstractString, x::AbstractVector{T},
-         y::AbstractVector{T}, z::AbstractVector{T}; kwargs...) where T =
-    vtk_grid(VTKRectilinearGrid(), filename, x, y, z; kwargs...)
-
-# 2D variant
-vtk_grid(filename::AbstractString, x::AbstractVector{T},
-         y::AbstractVector{T}; kwargs...) where T =
-    vtk_grid(VTKRectilinearGrid(), filename, x, y, Zeros{T}(1); kwargs...)
+function vtk_grid(
+        filename::AbstractString,
+        x::AbstractVector{T}, y::AbstractVector{T},
+        z::AbstractVector{T} = Zeros{T}(1);
+        kwargs...,
+    ) where {T}
+    vtk_grid(VTKRectilinearGrid(), filename, (x, y, z); kwargs...)
+end

--- a/src/gridtypes/structured/rectilinear.jl
+++ b/src/gridtypes/structured/rectilinear.jl
@@ -1,12 +1,11 @@
 function vtk_grid(
         dtype::VTKRectilinearGrid, filename::AbstractString,
         xs::Tuple{Vararg{AbstractVector, 3}};
-        extent = nothing, kwargs...,
+        extent = nothing, whole_extent = extent, kwargs...,
     )
     Ns = length.(xs)
     Npts = prod(Ns)
     Ncls = num_cells_structured(Ns)
-    ext = extent_attribute(Ns, extent)
 
     xvtk = XMLDocument()
     vtk = DatasetFile(dtype, xvtk, filename, Npts, Ncls; kwargs...)
@@ -16,11 +15,15 @@ function vtk_grid(
 
     # RectilinearGrid node
     xGrid = new_child(xroot, vtk.grid_type)
-    set_attribute(xGrid, "WholeExtent", ext)
+    let ext = extent_attribute(Ns, whole_extent)
+        set_attribute(xGrid, "WholeExtent", ext)
+    end
 
     # Piece node
     xPiece = new_child(xGrid, "Piece")
-    set_attribute(xPiece, "Extent", ext)
+    let ext = extent_attribute(Ns, extent)
+        set_attribute(xPiece, "Extent", ext)
+    end
 
     # Coordinates node
     xPoints = new_child(xPiece, "Coordinates")

--- a/src/gridtypes/structured/rectilinear.jl
+++ b/src/gridtypes/structured/rectilinear.jl
@@ -15,13 +15,13 @@ function vtk_grid(
 
     # RectilinearGrid node
     xGrid = new_child(xroot, vtk.grid_type)
-    let ext = extent_attribute(Ns, whole_extent)
+    let ext = extent_attribute(Ns, whole_extent; check = false)
         set_attribute(xGrid, "WholeExtent", ext)
     end
 
     # Piece node
     xPiece = new_child(xGrid, "Piece")
-    let ext = extent_attribute(Ns, extent)
+    let ext = extent_attribute(Ns, extent; check = true)
         set_attribute(xPiece, "Extent", ext)
     end
 

--- a/src/gridtypes/structured/rectilinear.jl
+++ b/src/gridtypes/structured/rectilinear.jl
@@ -3,8 +3,8 @@ function vtk_grid(dtype::VTKRectilinearGrid, filename::AbstractString,
                   extent=nothing, kwargs...)
     Ni, Nj, Nk = length(x), length(y), length(z)
     Npts = Ni*Nj*Nk
-    Ncls = num_cells_structured(Ni, Nj, Nk)
-    ext = extent_attribute(Ni, Nj, Nk, extent)
+    Ncls = num_cells_structured((Ni, Nj, Nk))
+    ext = extent_attribute((Ni, Nj, Nk), extent)
 
     xvtk = XMLDocument()
     vtk = DatasetFile(dtype, xvtk, filename, Npts, Ncls; kwargs...)

--- a/src/gridtypes/structured/structured.jl
+++ b/src/gridtypes/structured/structured.jl
@@ -15,8 +15,8 @@ function vtk_grid(dtype::VTKStructuredGrid, filename::AbstractString,
     Ni, Nj, Nk = structured_dims(xyz)
     Npts = Ni * Nj * Nk
     Ncomp = num_components(xyz, Npts)
-    Ncls = num_cells_structured(Ni, Nj, Nk)
-    ext = extent_attribute(Ni, Nj, Nk, extent)
+    Ncls = num_cells_structured((Ni, Nj, Nk))
+    ext = extent_attribute((Ni, Nj, Nk), extent)
 
     if Ncomp != 3  # three components (x, y, z)
         msg = "coordinate array `xyz` has incorrect dimensions.\n" *

--- a/src/gridtypes/structured/structured.jl
+++ b/src/gridtypes/structured/structured.jl
@@ -13,7 +13,7 @@ structured_dims(xyz::Array3ofVec3) = size(xyz)
 function vtk_grid(
         dtype::VTKStructuredGrid, filename::AbstractString,
         xyz::StructuredCoords;
-        extent = nothing, whole_extent = extent, kwargs...,
+        extent = structured_dims(xyz), whole_extent = extent, kwargs...,
     )
     Ns = structured_dims(xyz)
     Npts = prod(Ns)
@@ -36,13 +36,13 @@ function vtk_grid(
 
     # StructuredGrid node
     xGrid = new_child(xroot, vtk.grid_type)
-    let ext = extent_attribute(Ns, whole_extent; check = false)
+    let ext = extent_attribute(whole_extent)
         set_attribute(xGrid, "WholeExtent", ext)
     end
 
     # Piece node
     xPiece = new_child(xGrid, "Piece")
-    let ext = extent_attribute(Ns, extent; check = true)
+    let ext = extent_attribute(extent)
         set_attribute(xPiece, "Extent", ext)
     end
 

--- a/src/gridtypes/structured/structured.jl
+++ b/src/gridtypes/structured/structured.jl
@@ -36,13 +36,13 @@ function vtk_grid(
 
     # StructuredGrid node
     xGrid = new_child(xroot, vtk.grid_type)
-    let ext = extent_attribute(Ns, whole_extent)
+    let ext = extent_attribute(Ns, whole_extent; check = false)
         set_attribute(xGrid, "WholeExtent", ext)
     end
 
     # Piece node
     xPiece = new_child(xGrid, "Piece")
-    let ext = extent_attribute(Ns, extent)
+    let ext = extent_attribute(Ns, extent; check = true)
         set_attribute(xPiece, "Extent", ext)
     end
 

--- a/test/extent.jl
+++ b/test/extent.jl
@@ -5,24 +5,20 @@ using WriteVTK
     @testset "N = 2" begin
         Ns = (6, 8)
         ext = (1:6, 3:10)
-        @test_throws DimensionMismatch WriteVTK.extent_attribute(Ns .- 1, ext)
-        @test WriteVTK.extent_attribute(Ns .- 1, ext; check = false) == "1 6 3 10 0 0"  # disabling checks
-        @test WriteVTK.extent_attribute(Ns, ext) == "1 6 3 10 0 0"
         @test WriteVTK.extent_attribute(Ns) == "0 5 0 7 0 0"
+        @test WriteVTK.extent_attribute(ext) == "0 5 2 9 0 0"
     end
 
     @testset "N = 3" begin
         Ns = (6, 8, 42)
-        ext = (0:5, 0:7, 0:2)
-        @test_throws DimensionMismatch WriteVTK.extent_attribute(Ns, ext)
-        ext = (0:5, 0:7, 1:42)
-        @test WriteVTK.extent_attribute(Ns, ext) == "0 5 0 7 1 42"
+        ext = (1:6, 1:8, 1:3)
+        ext = (1:6, 1:8, 2:43)
+        @test WriteVTK.extent_attribute(ext) == "0 5 0 7 1 42"
         @test WriteVTK.extent_attribute(Ns) == "0 5 0 7 0 41"
     end
 
     @testset "N = 4" begin
         Ns = (3, 4, 5, 6)
-        ext = Base.OneTo.(Ns)
-        @test_throws ArgumentError WriteVTK.extent_attribute(Ns, ext)
+        @test_throws ArgumentError WriteVTK.extent_attribute(Ns)
     end
 end

--- a/test/extent.jl
+++ b/test/extent.jl
@@ -1,0 +1,27 @@
+using Test
+using WriteVTK
+
+@testset "Extent" begin
+    @testset "N = 2" begin
+        Ns = (6, 8)
+        ext = (1:6, 3:10)
+        @test_throws DimensionMismatch WriteVTK.extent_attribute(Ns .- 1, ext)
+        @test WriteVTK.extent_attribute(Ns, ext) == "1 6 3 10 0 0"
+        @test WriteVTK.extent_attribute(Ns) == "0 5 0 7 0 0"
+    end
+
+    @testset "N = 3" begin
+        Ns = (6, 8, 42)
+        ext = (0:5, 0:7, 0:2)
+        @test_throws DimensionMismatch WriteVTK.extent_attribute(Ns, ext)
+        ext = (0:5, 0:7, 1:42)
+        @test WriteVTK.extent_attribute(Ns, ext) == "0 5 0 7 1 42"
+        @test WriteVTK.extent_attribute(Ns) == "0 5 0 7 0 41"
+    end
+
+    @testset "N = 4" begin
+        Ns = (3, 4, 5, 6)
+        ext = Base.OneTo.(Ns)
+        @test_throws ArgumentError WriteVTK.extent_attribute(Ns, ext)
+    end
+end

--- a/test/extent.jl
+++ b/test/extent.jl
@@ -6,6 +6,7 @@ using WriteVTK
         Ns = (6, 8)
         ext = (1:6, 3:10)
         @test_throws DimensionMismatch WriteVTK.extent_attribute(Ns .- 1, ext)
+        @test WriteVTK.extent_attribute(Ns .- 1, ext; check = false) == "1 6 3 10 0 0"  # disabling checks
         @test WriteVTK.extent_attribute(Ns, ext) == "1 6 3 10 0 0"
         @test WriteVTK.extent_attribute(Ns) == "0 5 0 7 0 0"
     end

--- a/test/imagedata.jl
+++ b/test/imagedata.jl
@@ -33,7 +33,7 @@ function main()
     end
 
     # These are all optional:
-    extent = map(r -> r .+ 42, (1:Ni, 1:Nj, 1:Nk))
+    extent = map(r -> r .+ 43, (1:Ni, 1:Nj, 1:Nk))
     origin = (1.2, 4.3, -3.1)
     spacing = (0.1, 0.5, 1.2)
 

--- a/test/imagedata.jl
+++ b/test/imagedata.jl
@@ -33,9 +33,9 @@ function main()
     end
 
     # These are all optional:
-    extent = [1, Ni, 1, Nj, 1, Nk] .+ 42
-    origin = [1.2, 4.3, -3.1]
-    spacing = [0.1, 0.5, 1.2]
+    extent = map(r -> r .+ 42, (1:Ni, 1:Nj, 1:Nk))
+    origin = (1.2, 4.3, -3.1)
+    spacing = (0.1, 0.5, 1.2)
 
     # Initialise new vti file (image data).
     @time outfiles = vtk_grid(vtk_filename_noext, Ni, Nj, Nk, extent=extent,
@@ -59,7 +59,7 @@ function main()
 
     # Test 2D dataset
     @time outfiles_2D = vtk_grid(vtk_filename_noext * "_2D", Ni, Nj,
-                                 # extent=extent[1:2],  # doesn't work for now (TODO)
+                                 # extent=extent[1:2],
                                  origin=origin[1:2], spacing=spacing[1:2]) do vtk
         vtk["p_values"] = p[:, :, 1]
         vtk["myVector"] = vec[:, :, :, 1]

--- a/test/pvdCollection.jl
+++ b/test/pvdCollection.jl
@@ -54,7 +54,7 @@ function main()
     cdata = zeros(FloatType, Ni - 1, Nj - 1, Nk - 1)
 
     # Test extents (this is optional!!)
-    ext = [0, Ni-1, 0, Nj-1, 0, Nk-1] .+ 42
+    ext = map(N -> (1:N) .+ 42, (Ni, Nj, Nk))
 
     # Initialise pvd container file
     @time outfiles = paraview_collection(vtk_filename_noext) do pvd

--- a/test/rectilinear.jl
+++ b/test/rectilinear.jl
@@ -72,7 +72,7 @@ function main()
         end
 
         # Test extents (this is optional!!)
-        ext = [0, Ni-1, 0, Nj-1, 0, Nk-1] .+ 42
+        ext = map(N -> (1:N) .+ 42, (Ni, Nj, Nk))
 
         # Initialise new vtr file (rectilinear grid).
         @time begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using WriteVTK
 using Test: @test
 using SHA: sha1
 
+include("extent.jl")
+
 const tests = [
     "polyhedron_cube.jl",
     "multiblock.jl",

--- a/test/structured.jl
+++ b/test/structured.jl
@@ -69,9 +69,6 @@ function generate_structured(grid_format, ::Val{dim}) where {dim}
         end
     end
 
-    # Test extents (this is optional!!)
-    ext = [0, Ni-1, 0, Nj-1, 0, Nk-1]
-
     # We test defining grid points using different formats.
     points = if grid_format === SingleArray()
         xyz
@@ -96,7 +93,7 @@ function generate_structured(grid_format, ::Val{dim}) where {dim}
     @time begin
         # Initialise new vts file (structured grid).
         fname = "$(vtk_filename_noext)_$(dim)D_$(name(grid_format))"
-        vtk = vtk_grid(fname, points; extent=ext)
+        vtk = vtk_grid(fname, points)
 
         # Add data.
         vtk["p_values"] = psub


### PR DESCRIPTION
This simplifies and slightly modifies the behaviour of the `extent` keyword argument for structured grids:

- `extent` can no longer be given as a 6-element array `[x1, x2, y1, y2, z1, z2]`. Instead, it should be passed as a tuple of ranges: `(x1:x2, y1:y2, z1:z2)`.
- extents now expect one-based indexing. That is, `x1 = y1 = z1 = 1` by default. These are transformed to zero-based when writing to VTK.
- for image data files, `extent` is now taken into account for shifting the origin from the input coordinates.

Note that `extent` is undocumented, and in principle only to be used internally to write parallel formats (#98). Therefore this is not really considered a breaking change.
