### PR TITLE
Release allocated resources in Zlib, fixes #43.

### DIFF
--- a/src/write_data.jl
+++ b/src/write_data.jl
@@ -269,6 +269,7 @@ function data_to_xml_appended(vtk::DatasetFile, xDA::XMLElement, data)
         write_array(zWriter, data)
         write(zWriter, TranscodingStreams.TOKEN_END)
         flush(zWriter)
+        TranscodingStreams.finalize(zWriter.codec) # Release allocated resources (issue #43)
 
         # Go back to `initpos` and write real header.
         endpos = position(buf)


### PR DESCRIPTION
Together with @KristofferC I managed to find a solution to the memory leak issue (https://github.com/jipolanco/WriteVTK.jl/issues/43). It seems that the allocated resources in zlib are never released, but calling `finalize` does this.

It is a bit unclear from the TranscodingStreams documentation whether this is necessary, or if writing the `END_TOKEN` should do this. For example: https://juliaio.github.io/TranscodingStreams.jl/latest/#Wrapped-streams-1 hints that one must do something to release them, but in the code here we don't want to call `close(zWriter)` because that would also close the wrapped stream. https://juliaio.github.io/TranscodingStreams.jl/latest/examples/#Explicitly-finish-transcoding-by-writing-TOKEN_END-1 is a bit unclear what it means to "finishes the current transcoding process without closing the underlying stream", i.e. should that also release the allocated resources or not.

Draft for now, since it is possible this is a bug in TranscodingStreams (see https://github.com/JuliaIO/TranscodingStreams.jl/issues/117)