### PR TITLE
Make `vtk_surface` more consistent with `vtk_grid`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "WriteVTK"
 uuid = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com>"]
-version = "1.15.0"
+version = "1.15.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/tools/surface.md
+++ b/docs/src/tools/surface.md
@@ -9,7 +9,8 @@ This works in a similar way to surface plots in many plotting packages, e.g.
 ## Basic usage
 
 The `vtk_surface` function takes the coordinates `xs` and `ys` as well as the
-heights `zs` of the data:
+heights `zs` of the data.
+Other than that, it works in the same way as [`vtk_grid`](@ref):
 
 ```jldoctest surface
 julia> using WriteVTK
@@ -18,7 +19,10 @@ julia> xs = 0:0.5:10; ys = 0:1.0:20;
 
 julia> zs = @. cos(xs) + sin(ys');
 
-julia> vtk_surface("surf", xs, ys, zs)
+julia> vtk = vtk_surface("surf", xs, ys, zs)
+VTK file 'surf.vtu' (UnstructuredGrid file, open)
+
+julia> vtk_save(vtk)
 1-element Vector{String}:
  "surf.vtu"
 ```

--- a/test/surface.jl
+++ b/test/surface.jl
@@ -11,7 +11,10 @@ files = String[]
 @test_throws DimensionMismatch vtk_surface("will_fail", xs, [0.3, 0.4], zs)
 
 let
-    @time output = vtk_surface("surface_basic", xs, ys, zs)
+    @time output = let
+        vtk = vtk_surface("surface_basic", xs, ys, zs)
+        vtk_save(vtk)
+    end
     append!(files, output)
 end
 


### PR DESCRIPTION
When called without a function, `vtk_surface` now returns a VTK file handler just like `vtk_grid`.